### PR TITLE
[HWORKS-3077] Jupyter server SIGSEGVs on every directory listing on 5.0.x when hopsfsMount is disabled (pydoop PyMem_Free without GIL on Python 3.12)

### DIFF
--- a/src/native_core_hdfs/hdfs_fs.cc
+++ b/src/native_core_hdfs/hdfs_fs.cc
@@ -775,10 +775,12 @@ PyObject *FsClass_chown(FsInfo *self, PyObject *args, PyObject *kwds) {
     Py_BEGIN_ALLOW_THREADS;
         fileInfo = hdfsGetPathInfo(self->_fs, path);
         if (NULL == fileInfo) {
+            Py_BLOCK_THREADS; // we 'return' below, skipping over END_ALLOW_THREADS
+            PyErr_SetFromErrno(PyExc_IOError);
             PyMem_Free(path);
             PyMem_Free(input_user);
             PyMem_Free(input_group);
-	    return PyErr_SetFromErrno(PyExc_IOError);
+            return NULL;
         }
         const char* new_user = str_empty(input_user) ? fileInfo->mOwner : input_user;
         const char* new_group = str_empty(input_group) ? fileInfo->mGroup : input_group;

--- a/src/native_core_hdfs/hdfs_fs.cc
+++ b/src/native_core_hdfs/hdfs_fs.cc
@@ -564,7 +564,6 @@ PyObject *FsClass_list_directory(FsInfo *self, PyObject *args, PyObject *kwds) {
 
     Py_BEGIN_ALLOW_THREADS;
         pathInfo = hdfsGetPathInfo(self->_fs, path);
-        PyMem_Free(path);
         if (!pathInfo) {
             Py_BLOCK_THREADS; // later we 'goto' skipping over END_ALLOW_THREADS
             PyErr_SetFromErrno(PyExc_IOError);
@@ -617,6 +616,9 @@ error:
 
 done:
     // all code paths go through the 'done' section
+    // freed here, not next to hdfsGetPathInfo: PyMem_Free requires the GIL,
+    // which the ALLOW_THREADS region above has released
+    PyMem_Free(path);
     if (pathInfo != NULL)
         hdfsFreeFileInfo(pathInfo, 1);
     if (pathList != NULL)


### PR DESCRIPTION
## Summary
- On deployments with `hopsfsMount.enabled: false`, Jupyter's contents manager reaches HopsFS through the pydoop native extension (hdfscontents, pydoop, libhdfs). On Python 3.12 every directory listing crashed the Jupyter server with SIGSEGV in `PyMem_Free` and left the pod in `CrashLoopBackOff` ([HWORKS-3077](https://hopsworks.atlassian.net/browse/HWORKS-3077)).
- Cause: two sites in the extension call the Python C-API inside `Py_BEGIN_ALLOW_THREADS` regions, i.e. without holding the GIL. `FsClass_list_directory` frees the path buffer allocated by `PyArg_ParseTuple("es")` there on every call; `FsClass_chown`'s lookup-failure path frees three such buffers, raises the Python exception, and returns without restoring the saved thread state. CPython requires the GIL for `PyMem_*` calls (see References). Python 3.12 moved allocator state to the interpreter (PEP 684), so `PyMem_Free` now resolves its state through the current thread state, which `PyEval_SaveThread()` sets to NULL; the long-tolerated violation became a crash. Python 3.11 and earlier tolerated it, which is why 4.8.x worked with identical pydoop and why both `libhdfs-go` and `libhdfs-java` crash on 5.0.x.
- Fix: defer the listing path's free to the function's common exit section, which every post-parse path reaches with the GIL held; in the chown error path, re-acquire the GIL (`Py_BLOCK_THREADS`) before raising and freeing, with the raise first so errno is captured before the frees. No behaviour change on Python 3.11 and earlier.

## References
- [Memory Management, "Memory Interface"](https://docs.python.org/3.12/c-api/memory.html#memory-interface) (the `PyMem_Malloc`/`PyMem_Free` domain): "Warning: The GIL must be held when using these functions." The [3.11 docs](https://docs.python.org/3.11/c-api/memory.html) carry the identical warning, so the contract predates the crash; 3.11 simply did not enforce it.
- [Argument Parsing, `es` format unit](https://docs.python.org/3.12/c-api/arg.html): "PyArg_ParseTuple() will allocate a buffer of the needed size, copy the encoded data into this buffer and adjust *buffer to reference the newly allocated storage. The caller is responsible for calling PyMem_Free() to free the allocated buffer after use." The buffer is therefore in the PyMem domain by contract; the caller cannot pick a GIL-free allocator.
- [Memory Management, "Raw Memory Interface"](https://docs.python.org/3.12/c-api/memory.html#raw-memory-interface): "These functions are thread-safe, the GIL does not need to be held." The Raw domain is the only exempt one; the Object domain carries the same warning as PyMem.
- [Memory Management, "Debug hooks on the Python memory allocators"](https://docs.python.org/3.12/c-api/memory.html#debug-hooks-on-the-python-memory-allocators): debug CPython builds "check that the GIL is held when allocator functions of PYMEM_DOMAIN_OBJ (ex: PyObject_Malloc()) and PYMEM_DOMAIN_MEM (ex: PyMem_Malloc()) domains are called", which is why only release builds let this bug survive.
- [PEP 684, "A Per-Interpreter GIL"](https://peps.python.org/pep-0684/): the Python 3.12 change that moved allocator state into `PyInterpreterState` and made the violation fatal in practice.

## Remaining work on this draft
- Manual cluster verification is pending (see Test plan).

## Rollout note
The runtime base images install pydoop from `https://repo.hops.works/master/pydoop/pydoop-2.0.0-go-and-java.tar.gz` at image build time. Provenance of that artifact, reconstructed while preparing the verification build:

1. **The published tarball was built from the HOPSFS-156 tree (commit 72900d29, June 2024), not from the current branch.** `pydoop/hadoop_utils.py`, `pydoop/hdfs/core/__init__.py`, `src/libhdfs/hdfs.c`, and `pydoop/hdfs/fs.py` in the tarball match that commit byte for byte. Two edits sit on top of it uncommitted: `setup.py` additionally excludes the bundled libhdfs C sources, `__finalize_hdfs`, and `build_java()` (so the extension does not embed JNI libhdfs and the build needs no JDK), and `src/native_core_hdfs/hdfs_module.cc` drops `#include <jni.h>`. The build command was the `scripts/make_distro` script that HOPSFS-156 itself added (`CFLAGS=-I/usr/include/tirpc python setup.py sdist`), with the sdist renamed to the `-go-and-java` name; built around 2024-07-03, uploaded 2025-05-15. The branch has since reverted HOPSFS-156 and re-applied only its fs.py part (HOPSFS-255), so branch HEAD and the shipped artifact disagree on the jvmlib/hadoop-home behaviour and on `make_distro` itself (deleted by the revert). They need reconciling before a branch-based release path exists. `src/native_core_hdfs/hdfs_fs.cc` is identical across 72900d29, branch HEAD, and the tarball, so this PR's fixes are the only functional delta for the crash in any of those states.
2. **The branch as committed does not build on Python 3.12.** `pydoop/__init__.py` `read_properties()` uses `configparser.SafeConfigParser`, removed in Python 3.12. The published sdist avoids executing it only because it ships a pre-generated `pydoop/config.py`, which short-circuits `write_config()`. A source build from git needs `SafeConfigParser` replaced with `ConfigParser` (aliases of each other since Python 3.2).

After this merges, the artifact must be republished and the affected images rebuilt with a cache-safe mechanism (a same-URL republish can be masked by Docker layer caching, leaving rebuilt images on the stale tarball).

## Test plan
- [x] Syntax-only compile of the patched file against Python 3.12 headers (`python:3.12` container, `g++ -fsyntax-only`)
- [x] Patched wheel builds cleanly for the pod environment: published tarball + this PR's `hdfs_fs.cc`, `pip wheel --no-build-isolation` with `setuptools==80.10.2`, Python 3.12, linux/amd64 (`pydoop-2.0.0-cp312-cp312-linux_x86_64.whl`)
- [ ] Reproduce the crash on a 5.0.x cluster with `hopsfsMount.enabled: false` using the stock image (directory listing kills the pod)
- [ ] Rebuild the image with patched pydoop and verify manually: directory listing, file create/read/save, no SIGSEGV in pod logs, no CrashLoopBackOff
- [ ] `chown` on a nonexistent path returns IOError without crashing the process
- [ ] pydoop HDFS tests for the listing paths (populated, empty, nonexistent, empty-path) inside the patched image against the cluster's HopsFS

Not covered: the standard loadtest suite runs in mount mode and never exercises the hdfscontents/pydoop path, so it provides no signal for this change. The manual cluster verification above is the evidence for this ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HWORKS-3077]: https://hopsworks.atlassian.net/browse/HWORKS-3077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ